### PR TITLE
feat: trailing semicolon is now optional

### DIFF
--- a/questdb-confstr/README.md
+++ b/questdb-confstr/README.md
@@ -12,7 +12,7 @@ service::key1=value1;key2=value2;key3=value3;
 ```
 
 A few rules:
-* The last semicolon is mandatory.
+* The last semicolon is optional.
 * Service name and keys are case-sensitive.
 * Keys are ASCII alphanumeric and can contain underscores.
 * Values are case-sensitive unicode strings which can contain any characters,
@@ -21,10 +21,10 @@ A few rules:
 
 ## Grammar
 
-```plain
+```json
 conf_str ::= service "::" params | service
 service ::= identifier
-params ::= param (";" param)* ";"
+params ::= param (";" param)* ";"?
 param ::= key "=" value
 key ::= identifier
 value ::= { value_char }

--- a/questdb-confstr/src/lib.rs
+++ b/questdb-confstr/src/lib.rs
@@ -92,7 +92,6 @@ pub enum ErrorKind {
     BadSeparator((char, char)),
     IncompleteKeyValue,
     InvalidCharInValue(char),
-    MissingTrailingSemicolon,
     DuplicateKey(String),
 }
 
@@ -130,7 +129,6 @@ impl Display for ErrorKind {
                 write!(f, "incomplete key-value pair before end of input")
             }
             ErrorKind::InvalidCharInValue(c) => write!(f, "invalid char {:?} in value", c),
-            ErrorKind::MissingTrailingSemicolon => write!(f, "missing trailing semicolon"),
             ErrorKind::DuplicateKey(s) => write!(f, "duplicate key {:?}", s),
         }
     }

--- a/questdb-confstr/src/lib.rs
+++ b/questdb-confstr/src/lib.rs
@@ -197,7 +197,6 @@ fn parse_ident(
 fn parse_value(
     iter: &mut Peekable2<CharIndices>,
     next_pos: &mut Position,
-    input_len: usize,
 ) -> Result<Value, ParsingError> {
     let mut value = String::new();
     loop {
@@ -220,7 +219,7 @@ fn parse_value(
                 value.push(c);
                 let _ = iter.next();
             }
-            (None, _) => return Err(parse_err(ErrorKind::MissingTrailingSemicolon, input_len)),
+            (None, _) => break,
         }
     }
     Ok(value)
@@ -262,8 +261,8 @@ fn parse_params(
             Some((p, c)) => return Err(parse_err(ErrorKind::BadSeparator(('=', c)), p)),
             None => return Err(parse_err(ErrorKind::IncompleteKeyValue, input_len)),
         }
-        let value = parse_value(iter, next_pos, input_len)?;
-        iter.next().unwrap(); // skip ';'
+        let value = parse_value(iter, next_pos)?;
+        iter.next(); // skip ';', if present.
         params.insert(key, value);
     }
     Ok(params)

--- a/questdb-confstr/tests/tests.rs
+++ b/questdb-confstr/tests/tests.rs
@@ -259,23 +259,19 @@ fn test_incomplete_key_no_value() {
 #[test]
 fn missing_trailing_semicolon() {
     let input = "http::host=localhost;port=9000";
-    let config = parse_conf_str(input);
-    assert!(config.is_err());
-    let err = config.unwrap_err();
-    assert_eq!(ErrorKind::MissingTrailingSemicolon, err.kind());
-    assert_eq!(err.position(), 30);
-    assert_eq!(err.to_string(), "missing trailing semicolon at position 30");
+    let config = parse_conf_str(input).unwrap();
+    assert_eq!(config.service(), "http");
+    assert_eq!(config.get("host"), Some("localhost"));
+    assert_eq!(config.get("port"), Some("9000"));
 }
 
 #[test]
 fn escaped_semicolon_missing_trailing() {
     let input = "http::host=localhost;port=9000;;";
-    let config = parse_conf_str(input);
-    assert!(config.is_err());
-    let err = config.unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::MissingTrailingSemicolon);
-    assert_eq!(err.position(), 32);
-    assert_eq!(err.to_string(), "missing trailing semicolon at position 32");
+    let config = parse_conf_str(input).unwrap();
+    assert_eq!(config.service(), "http");
+    assert_eq!(config.get("host"), Some("localhost"));
+    assert_eq!(config.get("port"), Some("9000;"));
 }
 
 #[test]


### PR DESCRIPTION
Updated the documented grammar and parser implementation so that the trailing semi-colon is optional.

Closes https://github.com/questdb/questdb-confstr-rs/issues/3